### PR TITLE
2024-10-31 김재훈 / 11651

### DIFF
--- a/[김재훈] 좌표 정렬하기 2.cpp
+++ b/[김재훈] 좌표 정렬하기 2.cpp
@@ -1,0 +1,92 @@
+#include <iostream>
+using namespace std;
+
+typedef struct coord {
+  int x;
+  int y;
+} coord;
+
+void swap(coord &a, coord &b) {
+  coord temp = a;
+  a = b;
+  b = temp;
+}
+
+void insertion_sort(coord arr[], int start, int end) {
+  for (int i = start + 1; i <= end; i++) {
+    coord key = arr[i];
+    int j = i - 1;
+    while (j >= start && (arr[j].y > key.y || (arr[j].y == key.y && arr[j].x > key.x))) {
+      arr[j + 1] = arr[j];
+      j--;
+    }
+    arr[j + 1] = key;
+  }
+}
+
+void quick_sort(coord arr[], int start, int end) {
+  if (start >= end)
+    return;
+
+  if (end - start + 1 <= 15) {
+    insertion_sort(arr, start, end);
+    return;
+  }
+
+  int mid = (start + end) / 2;
+
+  if ((arr[start].y > arr[mid].y) || (arr[start].y == arr[mid].y && arr[start].x > arr[mid].x)) {
+    swap(arr[start], arr[mid]);
+  }
+  if ((arr[start].y > arr[end].y) || (arr[start].y == arr[end].y && arr[start].x > arr[end].x)) {
+    swap(arr[start], arr[end]);
+  }
+  if ((arr[mid].y > arr[end].y) || (arr[mid].y == arr[end].y && arr[mid].x > arr[end].x)) {
+    swap(arr[mid], arr[end]);
+  }
+
+  swap(arr[start], arr[mid]);
+  coord pivot = arr[start];
+
+  int left = start + 1;
+  int right = end;
+
+  while (left <= right) {
+    while (left <= end && (arr[left].y < pivot.y || (arr[left].y == pivot.y && arr[left].x < pivot.x))) {
+      left++;
+    }
+    while (right >= start && (arr[right].y > pivot.y || (arr[right].y == pivot.y && arr[right].x > pivot.x))) {
+      right--;
+    }
+    if (left <= right) {
+      swap(arr[left], arr[right]);
+      left++;
+      right--;
+    }
+  }
+
+  swap(arr[start], arr[right]);
+
+  quick_sort(arr, start, right - 1);
+  quick_sort(arr, right + 1, end);
+}
+
+int main() {
+  ios_base::sync_with_stdio(false);
+  cin.tie(nullptr);
+
+  int n;
+  cin >> n;
+
+  coord *arr = new coord[n];
+  for (int i = 0; i < n; i++) {
+    cin >> arr[i].x >> arr[i].y;
+  }
+
+  quick_sort(arr, 0, n - 1);
+
+  for (int i = 0; i < n; i++) {
+    cout << arr[i].x << " " << arr[i].y << "\n";
+  }
+  delete[] arr;
+}


### PR DESCRIPTION
quick sort는 배열의 한 원소를 기준으로 하여 오름차순의 경우
왼쪽에는 기준보다 작은 것들이 오른 쪽에는 기준보다 큰 것들이 위치하게끔 원소끼리 교환하고
다시 작은 것들이 모인 부분 배열과 큰 것들이 모인 부분 배열에서 각각 기준을 잡아
부분 배열의 길이가 0 또는 1이 될 때까지 재귀적으로 반복하여 정렬하는 알고리즘이다

최선의 경우는 두 부분 배열의 길이가 비슷하게끔 나눠지도록
즉 항상 중앙값을 기준으로 삼을 수 있으면 최선의 경우가 된다

가령 7 6 5 4 3 2 1을 오름차순으로 정렬하는 과정은 다음과 같다

깊이 1: 피벗은 4, 배열은 [1 2 3] [4] [5 6 7]로 분할
깊이 2: 왼쪽 부분 배열 [1 2 3]에서 피벗은 2, 배열은 [1] [2] [3]으로 분할
        오른쪽 부분 배열 [5 6 7]에서 피벗은 6, 배열은 [5] [6] [7]로 분할
깊이 3: 모든 부분 배열의 길이가 1이므로 정렬 완료

또한 각 깊이마다 부분배열의 원소를 전부 순회 하므로 O(n)의 시간이 걸린다
따라서 최선의 시간복잡도는 O(logn) x O(n) = O(nlogn)이다

최악의 경우는 이미 정렬된 배열에서 매 깊이마다 기준을 최솟값이나 최댓값으로 설정해
나눠진 부분 배열의 크기가 0이 되는 경우다

가령 1 2 3 4 5 6 7 을 오름차순으로 정렬하는 과정에서 최솟값을 기준으로 잡으면
깊이 1: 1 234567
깊이 2: 1 2 34567
깊이 3: 1 2 3 4567
깊이 4: 1 2 3 4 567
깊이 5: 1 2 3 4 5 67
깊이 6: 1 2 3 4 5 6 7
n번 재귀호출이 이뤄지고
내부 반복 또한 n번 이뤄지므로 시간 복잡도는 O(n^2)이 된다

quick sort는 기준을 고르는 방법에 따라 성능이 달라짐
  보통 랜덤하게 고르는 방법과 시작값 끝값 중앙값을 비교해 2등을 기준으로 고르는 방법이 있음
  내 코드에서는 후자를 적용해봤음


배열의 크기가 작으면 다음과 같은 이유로 삽입 정렬이 더 효율이 좋아진다

1 퀵소트의 재귀 호출로 인한 오버헤드
  배열을 분할할 때마다 재귀 호출이 발생
  각 재귀 호출은 함수 호출을 관리하기 위한 스택 프레임을 설정하고 해제하는 오버헤드 발생
  배열의 크기가 작은 경우, 이러한 오버헤드가 삽입정렬의 비교 및 교환보다 오래걸림

2 캐시(Locality of Reference) 활용
  삽입 정렬은 연속적인 메모리 위치에 접근 
  인접한 요소들 사이에서 이동이 발생
  이는 CPU 캐시의 지역성(Locality of Reference)을 효과적으로 활용하여 캐시 미스를 줄이고 성능을 향상

3 퀵소트의 분할로 인한 비연속적 접근
  퀵소트는 분할로 인해 메모리 접근 패턴이 비연속적
  작은 배열에서는 이러한 비효율적인 메모리 접근이 상대적으로 큰 성능 저하를 가져올 수 있음


파티션 알고리즘 선택: 
  대표적인 파티션 알고리즘으로는 Lomuto 파티션 스킴과 Hoare 파티션 스킴이 있습니다. 
  Hoare 방식이 일반적으로 더 빠르지만 구현이 복잡할 수 있음 
  Lomuto 방식은 구현이 간단하지만 교환 횟수가 많아질 수 있음
  
--------------------------------------------------------------------------------------------------------

삽입 정렬의 로직
  인덱스 1에서 시작
  현재 인덱스의 요소를 타겟변수에 저장
  타겟 변수와 이전 인덱스(현재는 1이므로 0)과 순서대로 비교
  타겟보다 크면 비교대상을 오른쪽으로 이동
  크지 않으면 타겟의 위치이므로 삽입
  반복
  
오름차순
  1 첫 번째 외부 반복 (인덱스 1):
  타겟 = 배열[1]
  배열[0]과 타겟을 비교
  배열[0] > 타겟이면:
  배열[1]에 배열[0]을 복사
  배열[0]에 타겟을 저장

  2 두 번째 외부 반복 (인덱스 2)
  타겟 = 배열[2]
  배열[1]과 타겟을 비교
  배열[1] > 타겟이면 배열[2]에 배열[1]을 복사하고, 다음으로 배열[0]과 비교
  배열[0] > 타겟이면 배열[1]에 배열[0]을 복사하고, 배열[0]에 타겟을 저장
  그렇지 않으면 배열[1]에 타겟을 저장

  3 반복

최악의 경우
  오름차순으로 정렬하려는데 내림차순으로 정렬되어 있는 경우
  비교할 때마다 타겟의 자리가 아니기 때문에 모든 남은 자료들과 비교가 발생
  1 + 2 + ... + n-1 = n(n-1)/2 즉 O(n^2)

최선의 경우
  오름차순으로 정렬하려는데 오름차순으로 정렬되어 있는 경우
  이미 자기 자리이기 때문에 각 외부 반복마다 1회의 비교만 발생
  외부 비교는 n-1회이기 때문에 n-1의 시간 소요 즉 O(n)

삽입 정렬의 시간 복잡도
  최악의 경우와 최선의 경우에서 알 수 있듯이 
  정렬된 정도가 높을수록 시간은 적게 걸린다
  n-1 <= O(n) <= n(n-1)/2 이므로 O(n^2)

또한 값이 같은 경우에는 쉬프팅이 발생하지 않기에 안정stable 정렬이고
정렬하기 위해서 추가적인 메모리가 필요하지 않기에 제자리in-place정렬이다