### PR TITLE
2024-12-31 김재훈 / 1697

### DIFF
--- a/김재훈/메모리 초과_숨바꼭질.cpp
+++ b/김재훈/메모리 초과_숨바꼭질.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <queue>
+#include <set>
+#include <vector>
+
+class TernaryTree {
+private:
+  int data;
+  int search;
+  int timer;
+  std::vector<TernaryTree *> children;
+
+public:
+  TernaryTree();
+  TernaryTree(int data, int search, int timer);
+
+  int printTimer();
+};
+
+TernaryTree::TernaryTree(int data, int search, int timer) : data(data), search(search), timer(timer), children(3) {}
+
+int TernaryTree::printTimer() {
+  std::queue<TernaryTree *> q;
+  std::set<int> foundNumber;
+
+  TernaryTree *root = this;
+  q.push(root);
+  foundNumber.insert(this->data);
+
+  while (!q.empty()) {
+    TernaryTree *current = q.front();
+    q.pop();
+
+    if (current->data == search) {
+      return current->timer;
+    }
+
+    int next1 = current->data - 1;
+    if (foundNumber.find(next1) == foundNumber.end()) {
+      TernaryTree *child1 = new TernaryTree(next1, search, current->timer + 1);
+      current->children.push_back(child1);
+      q.push(child1);
+      foundNumber.insert(next1);
+    }
+
+    int next2 = current->data * 2;
+    if (foundNumber.find(next2) == foundNumber.end()) {
+      TernaryTree *child2 = new TernaryTree(next2, search, current->timer + 1);
+      current->children.push_back(child2);
+      q.push(child2);
+      foundNumber.insert(next2);
+    }
+
+    int next3 = current->data + 1;
+    if (foundNumber.find(next3) == foundNumber.end()) {
+      TernaryTree *child3 = new TernaryTree(next3, search, current->timer + 1);
+      current->children.push_back(child3);
+      q.push(child3);
+      foundNumber.insert(next3);
+    }
+  }
+
+  return -1;
+}
+
+int main() {
+  int start;
+  int search;
+  std::cin >> start >> search;
+
+  TernaryTree *root = new TernaryTree(start, search, 0);
+
+  int timer = root->printTimer();
+  std::cout << timer;
+}

--- a/김재훈/숨바꼭질.cpp
+++ b/김재훈/숨바꼭질.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+
+int main() {
+  std::ios::sync_with_stdio(false);
+  std::cin.tie(nullptr);
+
+  int start;
+  int search;
+  std::cin >> start >> search;
+
+  if (start >= search) {
+    std::cout << start - search << std::endl;
+    return 0;
+  }
+
+  std::queue<int> q;
+  std::vector<int> timer(100001, -1);
+
+  timer[start] = 0;
+  q.push(start);
+
+  while (true) {
+    int current = q.front();
+    q.pop();
+
+    if (current == search) {
+      std::cout << timer[current];
+      return 0;
+    }
+
+    int next1 = current - 1;
+    if (next1 >= 0 && timer[next1] == -1) {
+      timer[next1] = timer[current] + 1;
+      q.push(next1);
+    }
+
+    int next2 = current * 2;
+    if (next2 <= 100000 && timer[next2] == -1) {
+      timer[next2] = timer[current] + 1;
+      q.push(next2);
+    }
+
+    int next3 = current + 1;
+    if (next3 <= 100000 && timer[next3] == -1) {
+      timer[next3] = timer[current] + 1;
+      q.push(next3);
+    }
+  }
+
+  return 0;
+}

--- a/김재훈/최적화 전_숨바꼭질.cpp
+++ b/김재훈/최적화 전_숨바꼭질.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+
+class TernaryTree {
+  int data;
+  int search;
+  int timer;
+
+public:
+  TernaryTree();
+  TernaryTree(int data, int search, int timer);
+
+  int printTimer();
+};
+
+TernaryTree::TernaryTree(int data, int search, int timer) : data(data), search(search), timer(timer) {}
+
+int TernaryTree::printTimer() {
+  std::queue<TernaryTree *> q;
+  std::vector<bool> foundNumber(100001, false);
+
+  TernaryTree *root = this;
+  q.push(root);
+  foundNumber[this->data] = true;
+
+  if (this->data > search) {
+    return this->data - search;
+  }
+
+  while (!q.empty()) {
+    TernaryTree *current = q.front();
+    q.pop();
+
+    if (current->data == search) {
+      return current->timer;
+    }
+
+    int next1 = current->data - 1;
+    if (next1 >= 0 && next1 <= 100000 && foundNumber[next1] == false) {
+      TernaryTree *child1 = new TernaryTree(next1, search, current->timer + 1);
+      q.push(child1);
+      foundNumber[next1] = true;
+    }
+
+    int next2 = current->data * 2;
+    if (next2 >= 0 && next2 <= 100000 && foundNumber[next2] == false) {
+      TernaryTree *child2 = new TernaryTree(next2, search, current->timer + 1);
+      q.push(child2);
+      foundNumber[next2] = true;
+    }
+
+    int next3 = current->data + 1;
+    if (next3 >= 0 && next3 <= 100000 && foundNumber[next3] == false) {
+      TernaryTree *child3 = new TernaryTree(next3, search, current->timer + 1);
+      q.push(child3);
+      foundNumber[next3] = true;
+    }
+  }
+
+  return -1;
+}
+
+int main() {
+  int start;
+  int search;
+  std::cin >> start >> search;
+
+  TernaryTree *root = new TernaryTree(start, search, 0);
+
+  int timer = root->printTimer();
+  std::cout << timer;
+}


### PR DESCRIPTION
이 문제는 특정 시작 지점(start)에서 목표 지점(search)까지 이동하는 데 필요한 최소 시간을 구하는 문제.

가능한 이동 연산은 현재 위치에서 -1, +1, ×2 

BFS(너비 우선 탐색)를 통하여 같은 시간동안 갈 수 있는 위치들을 탐색하고 다음 시간을 탐색.

1. **특수 케이스**  
   - 시작 위치가 목표 위치 이상이면, (start - search)만큼 뒤로 이동하는 것만이 유일하여 차이를 출력 후 종료.

2. **BFS 알고리즘**  
   - 큐(queue)에 시작 위치를 넣고, 각 위치에 도달하기까지 소요 시간을 저장하는 `timer` 배열을 사용.  
   - 매번 큐에서 원소를 꺼내, -1, +1, ×2를 적용해 이동할 수 있는 새로운 위치들을 확인한 뒤, 
   - 아직 방문하지 않은 위치라면 소요 시간을 업데이트하고 큐에 삽입.  
   - 목표 위치에 도달하면 `timer` 값을 출력하고 종료

3. **자료구조**  
   - `queue<int>`: BFS를 구현하기 위한 선입선출(FIFO) 큐.  
   - `vector<int>`: 각 지점에 도달하는 데 걸린 최소 시간을 저장. 방문 전에는 -1로 초기화하여 미방문 여부를 확인

4. **시간 복잡도**  
   - 각 위치는 한 번씩만 큐에 삽입. 즉 최악의 경우 시간 복잡도는 O(N)

5. **더욱 개선 가능하다고 생각되는 부분**
    - ×2 를 하여 나온 위치가 목표보다 큰 경우 거기서 부터는 뒤로만 갈 수 있으므로 뒤로 가는 연산만 실행하게끔 조건을 추가